### PR TITLE
Add deploy stack job

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,10 +1,10 @@
 name: Pipeline CI
 
-on: push
-  # push:
-  #   branches: [ "main" ]
-  # pull_request:
-  #   branches: [ "main" ]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   test:
@@ -43,13 +43,13 @@ jobs:
     - uses: cmb84scd/python-action@v1
     - run: just bandit
 
-  # safety:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: cmb84scd/python-action@v1
-  #   - uses: pyupio/safety-action@v1
-  #     with:
-  #       api-key: ${{ secrets.SAFETY_API_KEY }}
+  safety:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: cmb84scd/python-action@v1
+    - uses: pyupio/safety-action@v1
+      with:
+        api-key: ${{ secrets.SAFETY_API_KEY }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -53,6 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: Deploy
     needs: [test, lint, bandit]
+    env:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
     steps:
     - uses: cmb84scd/python-action@v1
     - uses: actions/setup-node@v4

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -70,5 +70,5 @@ jobs:
       with:
         aws-region: ${{ env.AWS_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE }}
-    - name: Bootstrap CDK
-      run: cdk bootstrap
+    - name: Deploy stack
+      run: cdk deploy --require-approval=never

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,4 +73,4 @@ jobs:
     - name: Deploy stack
       run: |
         poetry export --without-hashes -f requirements.txt -o requirements.txt
-        cat requirements.txt
+        poetry run cdk deploy --require-approval=never

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,6 +56,8 @@ jobs:
     env:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
+    permissions:
+      id-token: write
     steps:
     - uses: cmb84scd/python-action@v1
     - uses: actions/setup-node@v4

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,4 +73,5 @@ jobs:
     - name: Deploy stack
       run: |
         poetry export --without-hashes -f requirements.txt -o requirements.txt
-        poetry run cdk deploy --require-approval=never
+        cdk synth
+        # cdk deploy --require-approval=never

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -55,5 +55,10 @@ jobs:
     needs: [test, lint, bandit]
     steps:
     - uses: cmb84scd/python-action@v1
-    - name: Print out secret
-      run: echo "My secret:\ ${{ secrets }}"
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - name: Install CDK
+      run: npm install -g aws-cdk
+    - name: Synthesize CDK
+      run: cdk synth

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -72,5 +72,5 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE }}
     - name: Deploy stack
       run: |
-        poetry export -f requirements.txt -o requirements.txt
-        cdk deploy --require-approval=never
+        poetry export --without-hashes -f requirements.txt -o requirements.txt
+        cat requirements.txt

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -72,6 +72,8 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE }}
     - name: Deploy stack
       run: |
+        poetry env list
         poetry export --without-hashes -f requirements.txt -o requirements.txt
+        ls
         cdk synth
         cdk deploy --require-approval=never

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -54,7 +54,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: Deploy
-    needs: [test, lint, bandit]
+    needs: [test, lint, bandit, safety]
     env:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -72,8 +72,6 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE }}
     - name: Deploy stack
       run: |
-        poetry env list
+        just install
         poetry export --without-hashes -f requirements.txt -o requirements.txt
-        ls
-        cdk synth
         cdk deploy --require-approval=never

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,4 +71,6 @@ jobs:
         aws-region: ${{ env.AWS_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE }}
     - name: Deploy stack
-      run: cdk deploy --require-approval=never --verbose
+      run: |
+        poetry export -f requirements.txt
+        cdk deploy --require-approval=never --verbose

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,4 +56,4 @@ jobs:
     steps:
     - uses: cmb84scd/python-action@v1
     - name: Print out secret
-      run: echo "My secret:\ ${{ secrets.MY_SECRET }}"
+      run: echo "My secret:\ ${{ secrets }}"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: cmb84scd/python-action@v1
+    - name: Build package zip file
+      run: just build
     - name: Run tests
       run: just test-cov
     - name: Code Coverage Summary Report
@@ -72,7 +74,5 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE }}
     - name: Deploy stack
       run: |
-        poetry build
-        pip install --upgrade -t package dist/eventbus_learning-0.1.0-py3-none-any.whl
-        zip -r package.zip package
+        just build
         cdk deploy --require-approval=never

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,10 +1,10 @@
 name: Pipeline CI
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: push
+  # push:
+  #   branches: [ "main" ]
+  # pull_request:
+  #   branches: [ "main" ]
 
 jobs:
   test:
@@ -41,18 +41,18 @@ jobs:
     - uses: cmb84scd/python-action@v1
     - run: just bandit
 
-  safety:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cmb84scd/python-action@v1
-    - uses: pyupio/safety-action@v1
-      with:
-        api-key: ${{ secrets.SAFETY_API_KEY }}
+  # safety:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: cmb84scd/python-action@v1
+  #   - uses: pyupio/safety-action@v1
+  #     with:
+  #       api-key: ${{ secrets.SAFETY_API_KEY }}
 
   deploy:
     runs-on: ubuntu-latest
     environment: Deploy
-    needs: [test, lint, bandit, safety]
+    needs: [test, lint, bandit]
     steps:
     - uses: cmb84scd/python-action@v1
     - name: Print out secret

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -72,5 +72,5 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE }}
     - name: Deploy stack
       run: |
-        poetry export -f requirements.txt
-        cdk deploy --require-approval=never --verbose
+        poetry export -f requirements.txt -o requirements.txt
+        cdk deploy --require-approval=never

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -48,3 +48,12 @@ jobs:
     - uses: pyupio/safety-action@v1
       with:
         api-key: ${{ secrets.SAFETY_API_KEY }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    environment: Deploy
+    needs: [test, lint, bandit, safety]
+    steps:
+    - uses: cmb84scd/python-action@v1
+    - name: Print out secret
+      run: echo "My secret:\ ${{ secrets.MY_SECRET }}"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -74,4 +74,4 @@ jobs:
       run: |
         poetry export --without-hashes -f requirements.txt -o requirements.txt
         cdk synth
-        # cdk deploy --require-approval=never
+        cdk deploy --require-approval=never

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -63,5 +63,10 @@ jobs:
         node-version: 20
     - name: Install CDK
       run: npm install -g aws-cdk
-    - name: Synthesize CDK
-      run: cdk synth
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ env.AWS_REGION }}
+        role-to-assume: ${{ secrets.AWS_ROLE }}
+    - name: Bootstrap CDK
+      run: cdk bootstrap

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,4 +71,4 @@ jobs:
         aws-region: ${{ env.AWS_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE }}
     - name: Deploy stack
-      run: cdk deploy --require-approval=never
+      run: cdk deploy --require-approval=never --verbose

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -72,6 +72,7 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE }}
     - name: Deploy stack
       run: |
-        just install
-        poetry export --without-hashes -f requirements.txt -o requirements.txt
+        poetry build
+        pip install --upgrade -t package dist/eventbus_learning-0.1.0-py3-none-any.whl
+        zip -r package.zip package
         cdk deploy --require-approval=never

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: cmb84scd/python-action@v1
-    - name: Build package zip file
+    - name: Build package
       run: just build
     - name: Run tests
       run: just test-cov

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 reports/
 .env
 cdk.out/
+package.zip
 
 # IDE
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ __pycache__/
 reports/
 .env
 cdk.out/
-package.zip
+package/
 
 # IDE
 .vscode

--- a/app.py
+++ b/app.py
@@ -3,12 +3,12 @@
 
 import aws_cdk as cdk
 from decouple import config
-from eventbus_learning.infrastructure.stack import EventbusLearningStack
+from eventbus_learning.infrastructure.stack import EventBusLearningStack
 
 app = cdk.App()
-EventbusLearningStack(
+EventBusLearningStack(
     app,
-    "eventbus-learning",
+    "EventBusLearningStack",
     env=cdk.Environment(
         account=config("AWS_ACCOUNT_ID"), region=config("AWS_REGION")
     ),

--- a/cdk.json
+++ b/cdk.json
@@ -1,24 +1,22 @@
 {
   "app": "poetry run python app.py",
-  "watch": {
-    "include": [
-      "app.py",
-      "pyproject.toml",
-      "poetry.lock",
-      "requirements.txt",
-      "README.md",
-      "eventbus_learning/"
-    ],
-    "exclude": [
-      "cdk.out",
-      "source.bat",
-      "**/__pycache__/*",
-      ".pytest_cache",
-      "tests",
-      ".ruff_cache",
-      "reports",
-      ".coverage",
-      ".git"
-    ]
-  }
+  "include": [
+    "app.py",
+    "pyproject.toml",
+    "poetry.lock",
+    "requirements.txt",
+    "README.md",
+    "eventbus_learning/"
+  ],
+  "exclude": [
+    "cdk.out",
+    "source.bat",
+    "**/__pycache__/*",
+    ".pytest_cache",
+    "tests",
+    ".ruff_cache",
+    "reports",
+    ".coverage",
+    ".git"
+  ]
 }

--- a/cdk.json
+++ b/cdk.json
@@ -18,5 +18,6 @@
     "reports",
     ".coverage",
     ".git"
-  ]
+  ],
+  "build": "poetry install --no-root"
 }

--- a/cdk.json
+++ b/cdk.json
@@ -19,5 +19,5 @@
     ".coverage",
     ".git"
   ],
-  "build": "poetry install --no-root"
+  "build": "poetry install"
 }

--- a/cdk.json
+++ b/cdk.json
@@ -18,6 +18,5 @@
     "reports",
     ".coverage",
     ".git"
-  ],
-  "build": "poetry install"
+  ]
 }

--- a/cdk.json
+++ b/cdk.json
@@ -5,13 +5,15 @@
       "**/*.py"
     ],
     "exclude": [
-      "README.md",
-      "cdk*.json",
-      "requirements*.txt",
+      "cdk.out",
       "source.bat",
-      "**/__init__.py",
       "**/__pycache__/*",
-      "tests"
+      ".pytest_cache",
+      "tests",
+      ".ruff_cache",
+      "reports",
+      ".coverage",
+      ".git"
     ]
   }
 }

--- a/cdk.json
+++ b/cdk.json
@@ -2,7 +2,12 @@
   "app": "poetry run python app.py",
   "watch": {
     "include": [
-      "**/*.py"
+      "app.py",
+      "pyproject.toml",
+      "poetry.lock",
+      "requirements.txt",
+      "README.md",
+      "eventbus_learning/"
     ],
     "exclude": [
       "cdk.out",

--- a/eventbus_learning/infrastructure/stack.py
+++ b/eventbus_learning/infrastructure/stack.py
@@ -7,7 +7,7 @@ from aws_cdk import aws_sqs as sqs
 from constructs import Construct
 
 
-class EventbusLearningStack(Stack):
+class EventBusLearningStack(Stack):
     """Create resources for eventbus-learning stack."""
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:

--- a/eventbus_learning/infrastructure/stack.py
+++ b/eventbus_learning/infrastructure/stack.py
@@ -19,9 +19,9 @@ class EventBusLearningStack(Stack):
         lambda_.Function(
             self,
             "GetFactFunction",
-            code=lambda_.Code.from_asset("package.zip"),
+            code=lambda_.Code.from_asset("package"),
             dead_letter_queue=dlq,
-            handler="get_fact.handler",
+            handler="eventbus_learning.application.get_fact.handler",
             runtime=lambda_.Runtime.PYTHON_3_12,
         )
 

--- a/eventbus_learning/infrastructure/stack.py
+++ b/eventbus_learning/infrastructure/stack.py
@@ -21,7 +21,7 @@ class EventBusLearningStack(Stack):
             "GetFactFunction",
             code=lambda_.Code.from_asset("package.zip"),
             dead_letter_queue=dlq,
-            handler="eventbus_learning.application.get_fact.handler",
+            handler="get_fact.handler",
             runtime=lambda_.Runtime.PYTHON_3_12,
         )
 

--- a/eventbus_learning/infrastructure/stack.py
+++ b/eventbus_learning/infrastructure/stack.py
@@ -21,7 +21,7 @@ class EventBusLearningStack(Stack):
             "GetFactFunction",
             code=lambda_.Code.from_asset("package.zip"),
             dead_letter_queue=dlq,
-            handler="get_fact.handler",
+            handler="eventbus_learning.application.get_fact.handler",
             runtime=lambda_.Runtime.PYTHON_3_12,
         )
 

--- a/eventbus_learning/infrastructure/stack.py
+++ b/eventbus_learning/infrastructure/stack.py
@@ -19,7 +19,7 @@ class EventBusLearningStack(Stack):
         lambda_.Function(
             self,
             "GetFactFunction",
-            code=lambda_.Code.from_asset("eventbus_learning/application"),
+            code=lambda_.Code.from_asset("package.zip"),
             dead_letter_queue=dlq,
             handler="get_fact.handler",
             runtime=lambda_.Runtime.PYTHON_3_12,

--- a/justfile
+++ b/justfile
@@ -35,3 +35,9 @@ test:
 @test-cov:
     poetry run coverage run && poetry run coverage report
     poetry run coverage html && poetry run coverage xml --fail-under=95
+
+build:
+    poetry build
+    pip install --upgrade -t package dist/eventbus_learning-0.1.0-py3-none-any.whl
+    zip -r package.zip package
+    rm -r dist package

--- a/justfile
+++ b/justfile
@@ -39,5 +39,6 @@ test:
 build:
     poetry build
     pip install --upgrade -t package dist/eventbus_learning-0.1.0-py3-none-any.whl
+    cp -r eventbus_learning/application/* package
     zip -r package.zip package
     rm -r dist package

--- a/justfile
+++ b/justfile
@@ -39,6 +39,4 @@ test:
 build:
     poetry build
     pip install --upgrade -t package dist/eventbus_learning-0.1.0-py3-none-any.whl
-    cp -r eventbus_learning/application/* package
-    zip -r package.zip package
-    rm -r dist package
+    rm -r dist

--- a/poetry.lock
+++ b/poetry.lock
@@ -46,35 +46,35 @@ cryptography = "*"
 
 [[package]]
 name = "aws-cdk-asset-awscli-v1"
-version = "2.2.206"
+version = "2.2.209"
 description = "A library that contains the AWS CLI for use in Lambda Layers"
 optional = false
 python-versions = "~=3.8"
 files = [
-    {file = "aws_cdk.asset_awscli_v1-2.2.206-py3-none-any.whl", hash = "sha256:f1d665c0c0b0af0b2e686e1849af062b8a14aca21888f562b56844f83493647d"},
-    {file = "aws_cdk_asset_awscli_v1-2.2.206.tar.gz", hash = "sha256:2d438ae6b28deb85deec3ef1a3efc527797644c64321dd4a30093287a52550d4"},
+    {file = "aws_cdk.asset_awscli_v1-2.2.209-py3-none-any.whl", hash = "sha256:e917cb74062abf155a783ecaaf60542c0a726bd80a6318a66086dbb58866ba42"},
+    {file = "aws_cdk_asset_awscli_v1-2.2.209.tar.gz", hash = "sha256:fd19c4e1942bdd194390961d9877de338d2b737956fbad07ae5a2b0f7bc48a0d"},
+]
+
+[package.dependencies]
+jsii = ">=1.104.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<4.3.0"
+
+[[package]]
+name = "aws-cdk-asset-kubectl-v20"
+version = "2.1.3"
+description = "A Lambda Layer that contains kubectl v1.20"
+optional = false
+python-versions = "~=3.8"
+files = [
+    {file = "aws_cdk.asset_kubectl_v20-2.1.3-py3-none-any.whl", hash = "sha256:d5612e5bd03c215a28ce53193b1144ecf4e93b3b6779563c046a8a74d83a3979"},
+    {file = "aws_cdk_asset_kubectl_v20-2.1.3.tar.gz", hash = "sha256:237cd8530d9e8be0bbc7159af927dbb6b7f91bf3f4099c8ef4d9a213b34264be"},
 ]
 
 [package.dependencies]
 jsii = ">=1.103.1,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<5.0.0"
-
-[[package]]
-name = "aws-cdk-asset-kubectl-v20"
-version = "2.1.2"
-description = "A library that contains kubectl for use in Lambda Layers"
-optional = false
-python-versions = "~=3.7"
-files = [
-    {file = "aws-cdk.asset-kubectl-v20-2.1.2.tar.gz", hash = "sha256:346283e43018a43e3b3ca571de3f44e85d49c038dc20851894cb8f9b2052b164"},
-    {file = "aws_cdk.asset_kubectl_v20-2.1.2-py3-none-any.whl", hash = "sha256:7f0617ab6cb942b066bd7174bf3e1f377e57878c3e1cddc21d6b2d13c92d0cc1"},
-]
-
-[package.dependencies]
-jsii = ">=1.70.0,<2.0.0"
-publication = ">=0.0.3"
-typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-asset-node-proxy-agent-v6"
@@ -110,24 +110,24 @@ typeguard = ">=2.13.3,<5.0.0"
 
 [[package]]
 name = "aws-cdk-lib"
-version = "2.164.1"
+version = "2.165.0"
 description = "Version 2 of the AWS Cloud Development Kit library"
 optional = false
 python-versions = "~=3.8"
 files = [
-    {file = "aws_cdk_lib-2.164.1-py3-none-any.whl", hash = "sha256:758a84f806496193684b9fdf995f69cd24ce93fab2eba03a1a4cdb85115d2669"},
-    {file = "aws_cdk_lib-2.164.1.tar.gz", hash = "sha256:a0191479e3bed1579eff4df856efd30f34aca033a3b3ac1553743ac55b0820a2"},
+    {file = "aws_cdk_lib-2.165.0-py3-none-any.whl", hash = "sha256:6fa2f2b76345bf04256b06e2cafa3bcbab9a54eeb1b7c42b74b8a18920e09e4b"},
+    {file = "aws_cdk_lib-2.165.0.tar.gz", hash = "sha256:1fff96622fbafe48603c0633c62e1afa9fa72ac50bc3607ef385e395dc94c5f4"},
 ]
 
 [package.dependencies]
-"aws-cdk.asset-awscli-v1" = ">=2.2.202,<3.0.0"
-"aws-cdk.asset-kubectl-v20" = ">=2.1.2,<3.0.0"
+"aws-cdk.asset-awscli-v1" = ">=2.2.208,<3.0.0"
+"aws-cdk.asset-kubectl-v20" = ">=2.1.3,<3.0.0"
 "aws-cdk.asset-node-proxy-agent-v6" = ">=2.1.0,<3.0.0"
-"aws-cdk.cloud-assembly-schema" = ">=38.0.0,<39.0.0"
+"aws-cdk.cloud-assembly-schema" = ">=38.0.1,<39.0.0"
 constructs = ">=10.0.0,<11.0.0"
-jsii = ">=1.103.1,<2.0.0"
+jsii = ">=1.104.0,<2.0.0"
 publication = ">=0.0.3"
-typeguard = ">=2.13.3,<5.0.0"
+typeguard = ">=2.13.3,<4.3.0"
 
 [[package]]
 name = "bandit"
@@ -713,22 +713,22 @@ files = [
 
 [[package]]
 name = "jsii"
-version = "1.103.1"
+version = "1.104.0"
 description = "Python client for jsii runtime"
 optional = false
 python-versions = "~=3.8"
 files = [
-    {file = "jsii-1.103.1-py3-none-any.whl", hash = "sha256:24b96349230ca22f50fcd69c501e69b6c486acf37bbe0b5869f4c185572b079e"},
-    {file = "jsii-1.103.1.tar.gz", hash = "sha256:7eaa46e8cd9546edc6bba81d0b32df9f8ed8f5848305277d261cccfe00b9c1eb"},
+    {file = "jsii-1.104.0-py3-none-any.whl", hash = "sha256:c1da4d21be208db7dd341bc8fd9c4cdbaa5ff1a3cec7ce4f5f4e3ce89bc949cc"},
+    {file = "jsii-1.104.0.tar.gz", hash = "sha256:1e9b3e49797450258d473c16052258f2291bde4dd410d30c21e325c000c10a0c"},
 ]
 
 [package.dependencies]
 attrs = ">=21.2,<25.0"
-cattrs = ">=1.8,<23.3"
+cattrs = ">=1.8,<24.2"
 importlib-resources = ">=5.2.0"
 publication = ">=0.0.3"
 python-dateutil = "*"
-typeguard = ">=2.13.3,<5.0.0"
+typeguard = ">=2.13.3,<4.3.0"
 typing-extensions = ">=3.8,<5.0"
 
 [[package]]
@@ -1630,4 +1630,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "81784148c392aa88d5064225f0fd91d04682c1f601ee5f3005769ff460162330"
+content-hash = "1902dd34af88eae76001e3be394eff928a24b2434b9192f292ccf859681a0f68"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1630,4 +1630,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "1902dd34af88eae76001e3be394eff928a24b2434b9192f292ccf859681a0f68"
+content-hash = "bc3d136963ee7d4ef605e646f405e1635b599b118b96b6dad822818ed0a6d8ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Catriona Bennett <catrionamairi@blueyonder.co.uk>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-aws-cdk-lib = "^2.164.1"
+aws-cdk-lib = "^2.165.0"
 constructs = "^10.4.2"
 python = "^3.12"
 requests = "^2.32.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,16 +6,16 @@ authors = ["Catriona Bennett <catrionamairi@blueyonder.co.uk>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-aws-cdk-lib = "^2.165.0"
-constructs = "^10.4.2"
 python = "^3.12"
 requests = "^2.32.3"
 python-decouple = "^3.8"
 
 [tool.poetry.group.dev.dependencies]
+aws-cdk-lib = "^2.165.0"
 bandit = "^1.7.10"
 boto3 = "^1.35.52"
 botocore = "^1.35.52"
+constructs = "^10.4.2"
 coverage = "^7.6.4"
 pre-commit = "^4.0.1"
 pytest = "^8.3.3"

--- a/tests/unit_tests/infrastructure/test_stack.py
+++ b/tests/unit_tests/infrastructure/test_stack.py
@@ -1,11 +1,11 @@
 from aws_cdk import App
 from aws_cdk.assertions import Capture, Template
-from eventbus_learning.infrastructure.stack import EventbusLearningStack
+from eventbus_learning.infrastructure.stack import EventBusLearningStack
 
 from ..factories import iam_role_properties, lambda_properties
 
 app = App()
-stack = EventbusLearningStack(app, "eventbus-learning")
+stack = EventBusLearningStack(app, "eventbus-learning")
 template = Template.from_stack(stack)
 
 

--- a/tests/unit_tests/infrastructure/test_stack.py
+++ b/tests/unit_tests/infrastructure/test_stack.py
@@ -22,7 +22,7 @@ class TestEventBusLearningStack:
         template.has_resource_properties(
             "AWS::Lambda::Function",
             lambda_properties(
-                "eventbus_learning.application.get_fact.handler",
+                "get_fact.handler",
                 list(dlq)[0],
                 dependency_capture,
             ),

--- a/tests/unit_tests/infrastructure/test_stack.py
+++ b/tests/unit_tests/infrastructure/test_stack.py
@@ -22,7 +22,7 @@ class TestEventBusLearningStack:
         template.has_resource_properties(
             "AWS::Lambda::Function",
             lambda_properties(
-                "get_fact.handler",
+                "eventbus_learning.application.get_fact.handler",
                 list(dlq)[0],
                 dependency_capture,
             ),

--- a/tests/unit_tests/infrastructure/test_stack.py
+++ b/tests/unit_tests/infrastructure/test_stack.py
@@ -22,7 +22,9 @@ class TestEventBusLearningStack:
         template.has_resource_properties(
             "AWS::Lambda::Function",
             lambda_properties(
-                "get_fact.handler", list(dlq)[0], dependency_capture
+                "eventbus_learning.application.get_fact.handler",
+                list(dlq)[0],
+                dependency_capture,
             ),
         )
 


### PR DESCRIPTION
This PR adds a pipeline job to deploy the stack. The main things to note with this job are:
- It requires the other jobs (tests and linting) to have successfully run first before it can run
- It uses an environment for the deploy job. By using this, within the environment settings on GitHub, I was able to set a required reviewer, which makes the deploy job a manual one. This is important as I only want to deploy the stack when I want to due to the resources being used and the associated cost

Aside from the deploy job, I added a build recipe in the justfile as I need to package the dependencies so that the lambda knows about them. Doing this meant changing where it looks for the code, which broke the tests but I fixed this by adding the build recipe into the test job. I also added the package to gitignore as I need it locally but I don't want to commit it.

As a result of needing to package the dependencies, I realised that I don't need to include `aws-cdk-lib` and `constructs` as these are only needed to create the stack, and are not required at runtime. So, I moved them to `dev.dependencies` and in doing so, it also massively shrank the size of the package.

I also renamed the stack for consistency purposes so it now has a capital B in EventBus. It's also made it clearer in my opinion.

I did have a few issues along the way and once I'd got the dependencies to deploy, I realised that I have some other bugs. I haven't fixed them as part of this PR but they will be sorted in the next ticket (which I just created). I'm doing this as I didn't want to unnecessarily bloat this PR and I also want to look at the project structure, so I'll deal with all this next before I add any more resources.