### PR TITLE
Handle cat fact

### DIFF
--- a/cdk/__init__.py
+++ b/cdk/__init__.py
@@ -1,1 +1,1 @@
-"""This folder contains infrastructure code for the project."""
+"""This folder contains the cdk code for the project."""

--- a/cdk/base_constructs/__init__.py
+++ b/cdk/base_constructs/__init__.py
@@ -1,0 +1,1 @@
+"""This folder contains base cdk constructs."""

--- a/cdk/base_constructs/lambda_construct.py
+++ b/cdk/base_constructs/lambda_construct.py
@@ -20,7 +20,7 @@ class LambdaConstruct(Construct):
         """AWS base lambda construct."""
         super().__init__(scope, id, **kwargs)
 
-        base_lambda = lambda_.Function(
+        self.function = lambda_.Function(
             self,
             id,
             code=lambda_.Code.from_asset("package"),
@@ -31,8 +31,8 @@ class LambdaConstruct(Construct):
 
         if environment is not None:
             for k, v in environment.items():
-                base_lambda.add_environment(k, v)
+                self.function.add_environment(k, v)
 
         if policy is not None:
             for p in policy:
-                base_lambda.add_to_role_policy(p)
+                self.function.add_to_role_policy(p)

--- a/cdk/base_constructs/lambda_construct.py
+++ b/cdk/base_constructs/lambda_construct.py
@@ -14,7 +14,6 @@ class LambdaConstruct(Construct):
         handler: str,
         dead_letter_queue: str,
         environment: dict = None,
-        policy: list = None,
         **kwargs,
     ) -> None:
         """AWS base lambda construct."""
@@ -32,7 +31,3 @@ class LambdaConstruct(Construct):
         if environment is not None:
             for k, v in environment.items():
                 self.function.add_environment(k, v)
-
-        if policy is not None:
-            for p in policy:
-                self.function.add_to_role_policy(p)

--- a/cdk/base_constructs/lambda_construct.py
+++ b/cdk/base_constructs/lambda_construct.py
@@ -1,4 +1,4 @@
-"""Construct for an AWS Lambda Function."""
+"""Base construct for an AWS Lambda Function."""
 
 from aws_cdk import aws_lambda as lambda_
 from constructs import Construct

--- a/cdk/base_constructs/lambda_construct.py
+++ b/cdk/base_constructs/lambda_construct.py
@@ -16,7 +16,7 @@ class LambdaConstruct(Construct):
         environment: dict = None,
         **kwargs,
     ) -> None:
-        """AWS base lambda construct."""
+        """Initialise AWS base lambda construct."""
         super().__init__(scope, id, **kwargs)
 
         self.function = lambda_.Function(

--- a/cdk/fact_sorter_stack.py
+++ b/cdk/fact_sorter_stack.py
@@ -16,8 +16,13 @@ class FactSorterStack(Stack):
         """Create resources for Fact Sorter stack."""
         super().__init__(scope, id, **kwargs)
 
+        fact_bus_dlq = sqs.Queue(self, "AnimalFactBusDLQ")
+
         fact_bus = events.EventBus(
-            self, "AnimalFactBus", event_bus_name="animal_fact_bus"
+            self,
+            "AnimalFactBus",
+            event_bus_name="animal_fact_bus",
+            dead_letter_queue=fact_bus_dlq,
         )
 
         get_fact_policy = iam.PolicyStatement(

--- a/cdk/fact_sorter_stack.py
+++ b/cdk/fact_sorter_stack.py
@@ -57,9 +57,9 @@ class FactSorterStack(Stack):
             "CatFactRule",
             event_bus=fact_bus,
             event_pattern=events.EventPattern(
-                source=["aws.lambda"],
+                source=["GetFactFunction"],
                 detail_type=["fact.retrieved"],
-                detail={"animal_type": ["cat"]},
+                detail={"animal": ["cat"]},
             ),
             targets=[targets.LambdaFunction(handler=cat_fact_lambda.function)],
         )

--- a/cdk/fact_sorter_stack.py
+++ b/cdk/fact_sorter_stack.py
@@ -28,7 +28,7 @@ class FactSorterStack(Stack):
 
         get_fact_dlq = sqs.Queue(self, "GetFactDLQ")
 
-        get_fact_lamb = LambdaConstruct(
+        get_fact_lambda = LambdaConstruct(
             self,
             "GetFactFunction",
             handler="fact_sorter.application.get_fact.handler",
@@ -36,7 +36,7 @@ class FactSorterStack(Stack):
             environment={"EVENT_BUS_ARN": fact_bus.event_bus_arn},
         )
 
-        get_fact_lamb.function.add_to_role_policy(
+        get_fact_lambda.function.add_to_role_policy(
             iam.PolicyStatement(
                 actions=["events:PutEvents"],
                 resources=[fact_bus.event_bus_arn],

--- a/cdk/fact_sorter_stack.py
+++ b/cdk/fact_sorter_stack.py
@@ -26,20 +26,21 @@ class FactSorterStack(Stack):
             dead_letter_queue=fact_bus_dlq,
         )
 
-        get_fact_policy = iam.PolicyStatement(
-            actions=["events:PutEvents"],
-            resources=[fact_bus.event_bus_arn],
-        )
-
         get_fact_dlq = sqs.Queue(self, "GetFactDLQ")
 
-        LambdaConstruct(
+        get_fact_lamb = LambdaConstruct(
             self,
             "GetFactFunction",
             handler="fact_sorter.application.get_fact.handler",
             dead_letter_queue=get_fact_dlq,
             environment={"EVENT_BUS_ARN": fact_bus.event_bus_arn},
-            policy=[get_fact_policy],
+        )
+
+        get_fact_lamb.function.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["events:PutEvents"],
+                resources=[fact_bus.event_bus_arn],
+            )
         )
 
         cat_fact_dlq = sqs.Queue(self, "CatFactDLQ")

--- a/cdk/fact_sorter_stack.py
+++ b/cdk/fact_sorter_stack.py
@@ -6,7 +6,7 @@ from aws_cdk import aws_iam as iam
 from aws_cdk import aws_sqs as sqs
 from constructs import Construct
 
-from cdk.lambda_function import LambdaConstruct
+from cdk.base_constructs.lambda_construct import LambdaConstruct
 
 
 class FactSorterStack(Stack):

--- a/cdk/fact_sorter_stack.py
+++ b/cdk/fact_sorter_stack.py
@@ -3,39 +3,37 @@
 from aws_cdk import Stack
 from aws_cdk import aws_events as events
 from aws_cdk import aws_iam as iam
-from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_sqs as sqs
 from constructs import Construct
+
+from cdk.lambda_function import LambdaConstruct
 
 
 class FactSorterStack(Stack):
     """Create resources for Fact Sorter stack."""
 
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         """Create resources for Fact Sorter stack."""
-        super().__init__(scope, construct_id, **kwargs)
-
-        get_fact_dlq = sqs.Queue(self, "GetFactDLQ")
+        super().__init__(scope, id, **kwargs)
 
         fact_bus = events.EventBus(
             self, "AnimalFactBus", event_bus_name="animal_fact_bus"
         )
 
-        get_fact_lambda = lambda_.Function(
-            self,
-            "GetFactFunction",
-            code=lambda_.Code.from_asset("package"),
-            dead_letter_queue=get_fact_dlq,
-            handler="fact_sorter.application.get_fact.handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
-            environment={"EVENT_BUS_ARN": fact_bus.event_bus_arn},
+        get_fact_policy = iam.PolicyStatement(
+            actions=["events:PutEvents"],
+            resources=[fact_bus.event_bus_arn],
         )
 
-        get_fact_lambda.add_to_role_policy(
-            iam.PolicyStatement(
-                actions=["events:PutEvents"],
-                resources=[fact_bus.event_bus_arn],
-            )
+        get_fact_dlq = sqs.Queue(self, "GetFactDLQ")
+
+        LambdaConstruct(
+            self,
+            "GetFactFunction",
+            handler="fact_sorter.application.get_fact.handler",
+            dead_letter_queue=get_fact_dlq,
+            environment={"EVENT_BUS_ARN": fact_bus.event_bus_arn},
+            policy=[get_fact_policy],
         )
 
         events.Rule(
@@ -47,10 +45,11 @@ class FactSorterStack(Stack):
             ),
         )
 
-        lambda_.Function(
+        cat_fact_dlq = sqs.Queue(self, "CatFactDLQ")
+
+        LambdaConstruct(
             self,
             "CatFactFunction",
-            code=lambda_.Code.from_asset("package"),
             handler="fact_sorter.application.cat_fact.handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            dead_letter_queue=cat_fact_dlq,
         )

--- a/cdk/fact_sorter_stack.py
+++ b/cdk/fact_sorter_stack.py
@@ -46,3 +46,11 @@ class FactSorterStack(Stack):
                 source=["aws.lambda"],
             ),
         )
+
+        lambda_.Function(
+            self,
+            "CatFactFunction",
+            code=lambda_.Code.from_asset("package"),
+            handler="fact_sorter.application.cat_fact.handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+        )

--- a/cdk/lambda_function.py
+++ b/cdk/lambda_function.py
@@ -1,0 +1,38 @@
+"""Construct for an AWS Lambda Function."""
+
+from aws_cdk import aws_lambda as lambda_
+from constructs import Construct
+
+
+class LambdaConstruct(Construct):
+    """AWS base lambda construct."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        handler: str,
+        dead_letter_queue: str,
+        environment: dict = None,
+        policy: list = None,
+        **kwargs,
+    ) -> None:
+        """AWS base lambda construct."""
+        super().__init__(scope, id, **kwargs)
+
+        base_lambda = lambda_.Function(
+            self,
+            id,
+            code=lambda_.Code.from_asset("package"),
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            handler=handler,
+            dead_letter_queue=dead_letter_queue,
+        )
+
+        if environment is not None:
+            for k, v in environment.items():
+                base_lambda.add_environment(k, v)
+
+        if policy is not None:
+            for p in policy:
+                base_lambda.add_to_role_policy(p)

--- a/fact_sorter/application/cat_fact.py
+++ b/fact_sorter/application/cat_fact.py
@@ -3,7 +3,7 @@
 from fact_sorter.application.base.handler import BaseHandler
 
 
-class CatFactHandler(BaseHandler):
+class CatFactFunction(BaseHandler):
     """Handler to handle a cat fact."""
 
     def execute(self):
@@ -11,4 +11,4 @@ class CatFactHandler(BaseHandler):
         self.logger.info("Cat fact retrieved", self.event)
 
 
-handler = CatFactHandler.handler
+handler = CatFactFunction.handler

--- a/fact_sorter/application/cat_fact.py
+++ b/fact_sorter/application/cat_fact.py
@@ -9,3 +9,6 @@ class CatFactHandler(BaseHandler):
     def execute(self):
         """Log out the cat fact."""
         self.logger.info("Cat fact retrieved", self.event)
+
+
+handler = CatFactHandler.handler

--- a/fact_sorter/application/cat_fact.py
+++ b/fact_sorter/application/cat_fact.py
@@ -8,7 +8,8 @@ class CatFactFunction(BaseHandler):
 
     def execute(self):
         """Log out the cat fact."""
-        self.logger.info("Cat fact retrieved", self.event)
+        data = self.event["detail"]["fact"]
+        self.logger.info("Successfully collected cat fact", {"fact": data})
 
 
 handler = CatFactFunction.handler

--- a/fact_sorter/application/cat_fact.py
+++ b/fact_sorter/application/cat_fact.py
@@ -1,0 +1,11 @@
+"""Handler to handle a cat fact."""
+
+from fact_sorter.application.base.handler import BaseHandler
+
+
+class CatFactHandler(BaseHandler):
+    """Handler to handle a cat fact."""
+
+    def execute(self):
+        """Log out the cat fact."""
+        self.logger.info("Cat fact retrieved", self.event)

--- a/fact_sorter/application/get_fact.py
+++ b/fact_sorter/application/get_fact.py
@@ -1,5 +1,6 @@
 """Get an animal fact and put it onto the eventbus."""
 
+import json
 import os
 
 import boto3
@@ -20,7 +21,7 @@ class GetFactFunction(BaseHandler):
         try:
             fact = self.get_fact()
             event = {
-                "Detail": str(fact),
+                "Detail": json.dumps(fact),
                 "DetailType": "fact.retrieved",
                 "EventBusName": self.EVENT_BUS_ARN,
                 "Source": "GetFactFunction",

--- a/tests/unit_tests/cdk/base_constructs/test_lambda_construct.py
+++ b/tests/unit_tests/cdk/base_constructs/test_lambda_construct.py
@@ -1,3 +1,4 @@
+import pytest
 from aws_cdk import App, Stack
 from aws_cdk import aws_events as events
 from aws_cdk import aws_sqs as sqs
@@ -57,3 +58,18 @@ class TestLambdaConstruct:
                 list(event_bus_arn)[0],
             ),
         )
+
+    def test_construct_errors_when_required_params_are_missing(self):
+        app = App()
+        stack = Stack(app, "TestStack")
+
+        expected_message = (
+            r"LambdaConstruct.__init__\(\) missing 2 required positional "
+            r"arguments: 'handler' and 'dead_letter_queue'"
+        )
+
+        with pytest.raises(TypeError, match=expected_message):
+            LambdaConstruct(
+                stack,
+                "TestLambda",
+            )

--- a/tests/unit_tests/cdk/base_constructs/test_lambda_construct.py
+++ b/tests/unit_tests/cdk/base_constructs/test_lambda_construct.py
@@ -1,6 +1,5 @@
 from aws_cdk import App, Stack
 from aws_cdk import aws_events as events
-from aws_cdk import aws_iam as iam
 from aws_cdk import aws_sqs as sqs
 from aws_cdk.assertions import Capture, Template
 from cdk.base_constructs.lambda_construct import LambdaConstruct
@@ -57,35 +56,4 @@ class TestLambdaConstruct:
                 list(dlq)[0],
                 list(event_bus_arn)[0],
             ),
-        )
-
-    def test_lambda_has_iam_policy(self):
-        app = App()
-        stack = Stack(app, "TestStack")
-
-        test_dlq = sqs.Queue(stack, "TestDLQ")
-        test_policy = iam.PolicyStatement(
-            actions=["sqs:SendMessage"],
-            effect=iam.Effect.ALLOW,
-            resources=["*"],
-        )
-        LambdaConstruct(
-            stack,
-            "TestLambda",
-            handler="test_handler",
-            dead_letter_queue=test_dlq,
-            policy=[test_policy],
-        )
-
-        template = Template.from_stack(stack)
-        policy_capture = Capture()
-        role = template.find_resources("AWS::IAM::Role").keys()
-        policy = template.find_resources("AWS::IAM::Policy").keys()
-        template.has_resource_properties(
-            "AWS::IAM::Policy",
-            {
-                "PolicyDocument": policy_capture,
-                "PolicyName": list(policy)[0],
-                "Roles": [{"Ref": list(role)[0]}],
-            },
         )

--- a/tests/unit_tests/cdk/base_constructs/test_lambda_construct.py
+++ b/tests/unit_tests/cdk/base_constructs/test_lambda_construct.py
@@ -1,0 +1,91 @@
+from aws_cdk import App, Stack
+from aws_cdk import aws_events as events
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_sqs as sqs
+from aws_cdk.assertions import Capture, Template
+from cdk.base_constructs.lambda_construct import LambdaConstruct
+
+from ..factories import lambda_properties
+
+
+class TestLambdaConstruct:
+    def test_lambda_has_required_properties(self):
+        app = App()
+        stack = Stack(app, "TestStack")
+
+        test_dlq = sqs.Queue(stack, "TestDLQ")
+        LambdaConstruct(
+            stack,
+            "TestLambda",
+            handler="test_handler",
+            dead_letter_queue=test_dlq,
+        )
+
+        template = Template.from_stack(stack)
+        dependency_capture = Capture()
+        dlq = template.find_resources("AWS::SQS::Queue").keys()
+        template.has_resource_properties(
+            "AWS::Lambda::Function",
+            lambda_properties(
+                "test_handler", dependency_capture, list(dlq)[0]
+            ),
+        )
+
+    def test_lambda_has_environment_variable(self):
+        app = App()
+        stack = Stack(app, "TestStack")
+
+        test_bus = events.EventBus(stack, "TestBus")
+        test_dlq = sqs.Queue(stack, "TestDLQ")
+        LambdaConstruct(
+            stack,
+            "TestLambda",
+            handler="test_handler",
+            dead_letter_queue=test_dlq,
+            environment={"EVENT_BUS_ARN": test_bus.event_bus_arn},
+        )
+
+        template = Template.from_stack(stack)
+        dependency_capture = Capture()
+        dlq = template.find_resources("AWS::SQS::Queue").keys()
+        event_bus_arn = template.find_resources("AWS::Events::EventBus").keys()
+        template.has_resource_properties(
+            "AWS::Lambda::Function",
+            lambda_properties(
+                "test_handler",
+                dependency_capture,
+                list(dlq)[0],
+                list(event_bus_arn)[0],
+            ),
+        )
+
+    def test_lambda_has_iam_policy(self):
+        app = App()
+        stack = Stack(app, "TestStack")
+
+        test_dlq = sqs.Queue(stack, "TestDLQ")
+        test_policy = iam.PolicyStatement(
+            actions=["sqs:SendMessage"],
+            effect=iam.Effect.ALLOW,
+            resources=["*"],
+        )
+        LambdaConstruct(
+            stack,
+            "TestLambda",
+            handler="test_handler",
+            dead_letter_queue=test_dlq,
+            policy=[test_policy],
+        )
+
+        template = Template.from_stack(stack)
+        policy_capture = Capture()
+        role = template.find_resources("AWS::IAM::Role").keys()
+        policy = template.find_resources("AWS::IAM::Policy").keys()
+        template.has_resource_properties(
+            "AWS::IAM::Policy",
+            {
+                "PolicyDocument": policy_capture,
+                "PolicyName": list(policy)[0],
+                "Roles": [{"Ref": list(role)[0]}],
+            },
+        )

--- a/tests/unit_tests/cdk/factories/stack_resources.py
+++ b/tests/unit_tests/cdk/factories/stack_resources.py
@@ -1,13 +1,17 @@
 from aws_cdk.assertions import Match
 
 
-def lambda_properties(handler, dlq_name, dep_capture, env=None):
+def lambda_properties(handler, dep_capture, dlq_name=None, env=None):
     properties = {
-        "DeadLetterConfig": {"TargetArn": {"Fn::GetAtt": [dlq_name, "Arn"]}},
         "Handler": handler,
         "Role": {"Fn::GetAtt": [dep_capture, "Arn"]},
         "Runtime": "python3.12",
     }
+
+    if dlq_name is not None:
+        properties["DeadLetterConfig"] = {
+            "TargetArn": {"Fn::GetAtt": [dlq_name, "Arn"]}
+        }
 
     if env is not None:
         properties["Environment"] = {

--- a/tests/unit_tests/cdk/factories/stack_resources.py
+++ b/tests/unit_tests/cdk/factories/stack_resources.py
@@ -1,17 +1,13 @@
 from aws_cdk.assertions import Match
 
 
-def lambda_properties(handler, dep_capture, dlq_name=None, env=None):
+def lambda_properties(handler, dep_capture, dlq_name, env=None):
     properties = {
         "Handler": handler,
         "Role": {"Fn::GetAtt": [dep_capture, "Arn"]},
         "Runtime": "python3.12",
+        "DeadLetterConfig": {"TargetArn": {"Fn::GetAtt": [dlq_name, "Arn"]}},
     }
-
-    if dlq_name is not None:
-        properties["DeadLetterConfig"] = {
-            "TargetArn": {"Fn::GetAtt": [dlq_name, "Arn"]}
-        }
 
     if env is not None:
         properties["Environment"] = {

--- a/tests/unit_tests/cdk/test_fact_sorter_stack.py
+++ b/tests/unit_tests/cdk/test_fact_sorter_stack.py
@@ -80,7 +80,7 @@ class TestEventbus:
             "AWS::Events::Rule",
             {
                 "EventBusName": {"Ref": list(event_bus)[0]},
-                "EventPattern": {"source": ["aws.lambda"]},
+                "EventPattern": {"source": ["GetFactFunction"]},
                 "State": "ENABLED",
             },
         )

--- a/tests/unit_tests/cdk/test_fact_sorter_stack.py
+++ b/tests/unit_tests/cdk/test_fact_sorter_stack.py
@@ -76,12 +76,23 @@ class TestEventbus:
 
     def test_eventbus_rule_has_correct_properties(self):
         event_bus = template.find_resources("AWS::Events::EventBus").keys()
+        cat_fact_func = template.find_resources("AWS::Lambda::Function").keys()
         template.has_resource_properties(
             "AWS::Events::Rule",
             {
                 "EventBusName": {"Ref": list(event_bus)[0]},
-                "EventPattern": {"source": ["GetFactFunction"]},
+                "EventPattern": {
+                    "detail": {"animal": ["cat"]},
+                    "detail-type": ["fact.retrieved"],
+                    "source": ["GetFactFunction"],
+                },
                 "State": "ENABLED",
+                "Targets": [
+                    {
+                        "Arn": {"Fn::GetAtt": [list(cat_fact_func)[1], "Arn"]},
+                        "Id": "Target0",
+                    }
+                ],
             },
         )
 

--- a/tests/unit_tests/cdk/test_fact_sorter_stack.py
+++ b/tests/unit_tests/cdk/test_fact_sorter_stack.py
@@ -14,7 +14,7 @@ class TestFactSorterStack:
         template.resource_count_is("AWS::Lambda::Function", 2)
         template.resource_count_is("AWS::Events::EventBus", 1)
         template.resource_count_is("AWS::Events::Rule", 1)
-        template.resource_count_is("AWS::SQS::Queue", 1)
+        template.resource_count_is("AWS::SQS::Queue", 2)
 
 
 class TestGetFactLambda:

--- a/tests/unit_tests/cdk/test_fact_sorter_stack.py
+++ b/tests/unit_tests/cdk/test_fact_sorter_stack.py
@@ -83,15 +83,18 @@ class TestEventbus:
 class TestCatFactLambda:
     def test_lambda_has_correct_properties(self):
         dependency_capture = Capture()
+        dlq = template.find_resources("AWS::SQS::Queue").keys()
         template.has_resource_properties(
             "AWS::Lambda::Function",
             lambda_properties(
                 "fact_sorter.application.cat_fact.handler",
                 dependency_capture,
+                list(dlq)[1],
             ),
         )
 
         assert "CatFactFunctionServiceRole" in dependency_capture.as_string()
+        assert "CatFactDLQ" in list(dlq)[1]
 
     def test_lambda_has_correct_iam_role(self):
         role_capture = Capture()

--- a/tests/unit_tests/cdk/test_fact_sorter_stack.py
+++ b/tests/unit_tests/cdk/test_fact_sorter_stack.py
@@ -16,7 +16,9 @@ class TestFactSorterStack:
         template.resource_count_is("AWS::Events::Rule", 1)
         template.resource_count_is("AWS::SQS::Queue", 1)
 
-    def test_get_fact_lambda_has_correct_properties(self):
+
+class TestGetFactLambda:
+    def test_lambda_has_correct_properties(self):
         dependency_capture = Capture()
         dlq = template.find_resources("AWS::SQS::Queue").keys()
         event_bus_arn = template.find_resources("AWS::Events::EventBus").keys()
@@ -33,7 +35,7 @@ class TestFactSorterStack:
         assert "GetFactFunctionServiceRole" in dependency_capture.as_string()
         assert "GetFactDLQ" in list(dlq)[0]
 
-    def test_get_fact_lambda_has_correct_iam_role(self):
+    def test_lambda_has_correct_iam_role(self):
         role_capture = Capture()
         role = template.find_resources("AWS::IAM::Role").keys()
         template.has_resource_properties(
@@ -43,7 +45,7 @@ class TestFactSorterStack:
         assert "AWSLambdaBasicExecutionRole" in role_capture.as_string()
         assert "GetFactFunctionServiceRole" in list(role)[0]
 
-    def test_get_fact_lambda_has_correct_policy(self):
+    def test_lambda_has_correct_policy(self):
         policy_capture = Capture()
         role = template.find_resources("AWS::IAM::Role").keys()
         policy = template.find_resources("AWS::IAM::Policy").keys()
@@ -56,6 +58,8 @@ class TestFactSorterStack:
             },
         )
 
+
+class TestEventbus:
     def test_eventbus_has_correct_properties(self):
         template.has_resource_properties(
             "AWS::Events::EventBus",
@@ -75,7 +79,9 @@ class TestFactSorterStack:
             },
         )
 
-    def test_cat_fact_lambda_has_correct_properties(self):
+
+class TestCatFactLambda:
+    def test_lambda_has_correct_properties(self):
         dependency_capture = Capture()
         template.has_resource_properties(
             "AWS::Lambda::Function",
@@ -87,7 +93,7 @@ class TestFactSorterStack:
 
         assert "CatFactFunctionServiceRole" in dependency_capture.as_string()
 
-    def test_cat_fact_lambda_has_correct_iam_role(self):
+    def test_lambda_has_correct_iam_role(self):
         role_capture = Capture()
         role = template.find_resources("AWS::IAM::Role").keys()
         template.has_resource_properties(

--- a/tests/unit_tests/fact_sorter/application/test_cat_fact.py
+++ b/tests/unit_tests/fact_sorter/application/test_cat_fact.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fact_sorter.application.base.logger import Logger
+from fact_sorter.application.cat_fact import CatFactFunction
+
+
+class TestCatFactFunction:
+    @pytest.fixture(autouse=True)
+    def logger(self):
+        yield MagicMock(wraps=Logger())
+
+    @pytest.fixture
+    def handler(self, logger):
+        class MockLoggerHandler(CatFactFunction):
+            def __init__(self, event, context):
+                super().__init__(event, context)
+
+                self.logger = logger
+
+        yield MockLoggerHandler(None, None)
+
+    def test_excute_logs_cat_fact(self, handler):
+        handler.event = {
+            "version": "0",
+            "id": "123abc456",
+            "detail-type": "fact.retrieved",
+            "source": "GetFactFunction",
+            "account": "1234567890",
+            "time": "2023-01-01T00:00:00Z",
+            "region": "an-aws-region",
+            "resources": [],
+            "detail": {"animal": "cat", "fact": "Cats have 9 lives"},
+        }
+        expected_data = {"fact": "Cats have 9 lives"}
+        handler.execute()
+
+        handler.logger.info.assert_called_once_with(
+            "Successfully collected cat fact", expected_data
+        )

--- a/tests/unit_tests/fact_sorter/application/test_get_fact.py
+++ b/tests/unit_tests/fact_sorter/application/test_get_fact.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import ANY, MagicMock
 
 import pytest
@@ -71,8 +72,9 @@ class TestHandler:
 
     def test_puts_the_fact_on_the_event_bus(self, handler, events_stub):
         response = {"Entries": [{"EventId": "1"}], "FailedEntryCount": 0}
+        fact = {"animal": "cat", "fact": "A cat fact."}
         event = {
-            "Detail": "{'animal': 'cat', 'fact': 'A cat fact.'}",
+            "Detail": json.dumps(fact),
             "DetailType": "fact.retrieved",
             "EventBusName": handler.EVENT_BUS_ARN,
             "Source": "GetFactFunction",
@@ -83,9 +85,7 @@ class TestHandler:
 
         expected_info_log = ["Sending fact to eventbus", event]
 
-        handler.get_fact = MagicMock(
-            return_value={"animal": "cat", "fact": "A cat fact."}
-        )
+        handler.get_fact = MagicMock(return_value=fact)
         handler.execute()
 
         handler.logger.info.assert_called_once_with(*expected_info_log)


### PR DESCRIPTION
This PR adds a lambda to log out only cat facts. There is a rule on the event bus to ensure that only cat facts trigger this lambda. I amended the existing rule as it wasn't being used as I had originally added it for reference but knowing that I would need it at some point!

In adding the cat fact lambda, I was starting to duplicate some lambda code within CDK. Knowing that I will add another lambda, I created a base lambda construct to DRY up the code.

I also made some minor changes as some things weren't clear or due to there being a better way to do something. The latter was using `json.dumps` when putting the fact onto the bus instead of `str()` as doing it the way I was, didn't actually feel right based on examples I saw online.

Unit tests were updated where necessary and I also did unit tests for the code I added.